### PR TITLE
Various configuration improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ Usage
 2. `gem install sentry-raven`
 3. `git clone https://github.com/DamianZaremba/sentry-puppet.git /etc/puppet/<environment>/modules/sentry/`
 4. `cp /etc/puppet/<environment>/modules/sentry/sentry.yaml /etc/puppet/<environment>/`
-5. Update sentry.yaml with your dsn
-6. Enable pluginsync and reports
+5. Add required configuration to Hiera:
+
+        {"sentry": {"dsn": "SENTRY_DSN"}}
+
+6. Enable pluginsync and reports:
 
         [master]
         report = true

--- a/lib/puppet/reports/sentry.rb
+++ b/lib/puppet/reports/sentry.rb
@@ -1,5 +1,5 @@
+require 'hiera_puppet'
 require 'puppet'
-require 'yaml'
 
 begin
     require 'rubygems'
@@ -10,21 +10,11 @@ end
 begin
     require 'raven'
 rescue LoadError => e
-    Puppet.err "You need the `raven-sentry` gem installed on the puppetmaster to send reports to Sentry"
+    Puppet.err "You need the `sentry-raven` gem installed on the puppetmaster to send reports to Sentry"
 end
 
 Puppet::Reports.register_report(:sentry) do
-    # Description
     desc = 'Puppet reporter designed to send failed runs to a sentry server'
-
-    # Load the config else error
-    config_path = File.join([File.dirname(Puppet.settings[:config]), "sentry.yaml"])
-
-    unless File.exist?(config_path)
-        raise(Puppet::ParseError, "Sentry config " + config_path + " doesn't exist")
-    end
-
-    CONFIG = YAML.load_file(config_path)
 
     # Process an event
     def process
@@ -33,16 +23,12 @@ Puppet::Reports.register_report(:sentry) do
             return
         end
 
+        config = HieraPuppet.lookup('sentry', {}, self, nil, :priority)
+
         # Check the config contains what we need
-        if not CONFIG[:sentry_dsn]
+        if not config[:dsn]
             raise(Puppet::ParseError, "Sentry did not contain a dsn")
         end
-
-         if self.respond_to?('environment')
-             @environment = self.environment
-         else
-             @environment = 'production'
-         end
 
          if self.respond_to?(:host)
              @host = self.host
@@ -61,24 +47,22 @@ Puppet::Reports.register_report(:sentry) do
 
         # Configure raven
         Raven.configure do |config|
-            config.dsn = CONFIG[:sentry_dsn]
-            config.current_environment = @environment
+            config.dsn = config[:dsn]
         end
 
         # Get the important looking stuff to sentry
         self.logs.each do |log|
             if log.level.to_s == 'err'
-                Raven.captureMessage(log.message + " at " + log.file + ":" + log.line.to_s, {
+                Raven.captureMessage(log.message, {
                   :server_name => @host,
                   :tags => {
-                    'environment' => @environment,
                     'status'      => @status,
                     'version'     => @puppet_version,
                     'kind'        => @kind,
                   },
                   :extra => {
                     'source' => log.source,
-                    'line'   => log.line.to_s,
+                    'line'   => log.line,
                     'file'   => log.file,
                   },
                 })


### PR DESCRIPTION
- Read from Hiera (instead of sentry.yaml)
- Ignore environment (not available by default on systems)

These may not matter upstream (i.e. the environment thing probably should still exist, but it didn't apply in our cases and caused errors).
